### PR TITLE
Remove the need for a hard-coded "admin/metrilyx" user; various other small enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ test.py
 ##########
 *.pyc
 *.pyo
+env
+.idea
 
 # OS generated files #
 ######################

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -66,7 +66,7 @@ If you would like to use postgres for the backend database instead of the defaul
 
 You will also need to create the appropriate schemas in postgres and re-initialize django.
 
-To initialize django for postgres, issue the command below.  If you get prompted to create a superuser, use the following credentials **admin/metrilyx**.  Setting them to anything else will cause the application to fail.  This is due to the fact that authentication has not been fully integrated and disabled in metrilyx.
+To initialize django for postgres, issue the command below.  If you get prompted to create a superuser, use the following credentials **admin/metrilyx**.  Setting them to anything else may cause the application to fail.
 
 	$ cd /opt/metrilyx
 	$ python manage.py syncdb

--- a/metrilyx/dataserver/cli.py
+++ b/metrilyx/dataserver/cli.py
@@ -34,7 +34,7 @@ class DataserverOptionParser(OptionParser):
             print "[ERROR] %s" %(str(e))
             sys.exit(2)
 
-    def parse_args(self):
+    def parse_args(self, args=None, values=None):
         opts, args = OptionParser.parse_args(self)
         setattr(opts, "logger", self.__getLogger(opts))
         opts.logger.warning("* Log level: %s" % (opts.logLevel))

--- a/metrilyx/dataserver/httpfetcher.py
+++ b/metrilyx/dataserver/httpfetcher.py
@@ -14,7 +14,7 @@ from twisted.web.client import Agent
 from twisted.web.http_headers import Headers
 from twisted.web.iweb import IBodyProducer
 from twisted.internet.defer import Deferred, succeed
-from twisted.internet.protocol import Protocol
+from twisted.internet.protocol import Protocol, connectionDone
 
 from metrilyx.metrilyxconfig import config
 
@@ -220,7 +220,7 @@ class AsyncHttpResponseProtocol(Protocol):
         except Exception,e:
             return json.dumps({"error": str(e)})
 
-    def connectionLost(self, reason):
+    def connectionLost(self, reason=connectionDone):
         if self.headers.hasHeader('content-encoding') and \
                 ('gzip' in self.headers.getRawHeaders('content-encoding')):
             self.finished.callback(self.__ungzip_())

--- a/metrilyx/dataserver/transforms.py
+++ b/metrilyx/dataserver/transforms.py
@@ -1,4 +1,5 @@
 
+import time
 import logging
 
 import numpy
@@ -24,6 +25,8 @@ def absoluteTime(relTime, convertTo='micro'):
 
     val = int(relTime.split("-")[0][:-1])
     unit = relTime.split("-")[0][-1]
+
+    retVal = None
 
     if unit == 's':
         retVal = time.time() - val
@@ -107,8 +110,7 @@ class BasicSerie(object):
         """
         flat_obj = self._flatten_dict(obj)
         ## set unique tags string
-        if unique_tags_str:
-            uniqueTagsString = unique_tags_str %(flat_obj)
+        uniqueTagsString = unique_tags_str %(flat_obj) if unique_tags_str else None
 
         normalizedAlias = alias_str
         # When alias_str starts with ! we will do an eval for lambda processing
@@ -275,7 +277,7 @@ class MetrilyxSerie(BasicSerie):
             if toMillisecs:
                 return [ (int(tsval[0])*1000, tsval[1]) for tsval in sorted(data) ]
             else:
-                return [ (int(tsval[0]), tsval[1]) for ts in sorted(data) ]
+                return [ (int(tsval[0]), tsval[1]) for tsval in sorted(data) ]
 
 
     def __rmNegativeRates(self, data):

--- a/metrilyx/metrilyxconfig.py
+++ b/metrilyx/metrilyxconfig.py
@@ -12,14 +12,14 @@ _abspath = os.path.abspath(__file__)
 
 _apphome = os.environ.get('METRILYX_HOME')
 if _apphome == None:
-	print " * Warning: METRILYX_HOME environment variable not set!"
-	_apphome = os.path.dirname(os.path.dirname(_abspath))
+    print " * Warning: METRILYX_HOME environment variable not set!"
+    _apphome = os.path.dirname(os.path.dirname(_abspath))
 
 _appversion = open(os.path.join(_apphome, "VERSION")).read()
 
 CONFIG_FILE = os.path.join(_apphome, "etc/metrilyx/metrilyx.conf")
 if not os.path.exists(CONFIG_FILE):
-	raise RuntimeError("Configuration file not found: %s!" % (CONFIG_FILE))
+    raise RuntimeError("Configuration file not found: %s!" % (CONFIG_FILE))
 
 
 try:
@@ -29,7 +29,7 @@ except Exception, e:
         
 
 if config.has_key("error"):
-	raise RuntimeError("Configuration error: %s" %(str(config)))
+    raise RuntimeError("Configuration error: %s" %(str(config)))
 
 # Check version
 if not config.has_key("version"):
@@ -40,10 +40,10 @@ elif config["version"] != _appversion:
 
 
 if not config.has_key("static_path"):
-	config["static_path"] = os.path.join(os.path.dirname(_apphome), "www")
+    config["static_path"] = os.path.join(os.path.dirname(_apphome), "www")
 
 if not config.has_key("schema_path"):
-	config["schema_path"] = os.path.join(_apphome, "etc/metrilyx/schemas")
+    config["schema_path"] = os.path.join(_apphome, "etc/metrilyx/schemas")
 
 if config["version"].startswith("2.4"):
     adp = config['annotations']['dataprovider']

--- a/metrilyx/models.py
+++ b/metrilyx/models.py
@@ -42,7 +42,7 @@ class MapModel(models.Model):
 
 	_id = models.CharField(max_length=128,primary_key=True)
 	name = models.CharField(max_length=128, default="", blank=True)
-	layout = layout = jsonfield.JSONField(default=[], null=True, blank=True)
+	layout = jsonfield.JSONField(default=[], null=True, blank=True)
 	user = models.ForeignKey('auth.User', related_name='mapmodels')
 	group = models.ForeignKey('auth.Group', related_name='mapmodels', null=True, blank=True)
 	tags = jsonfield.JSONField(default=[], null=True, blank=True)

--- a/metrilyx/rest/apiviews.py
+++ b/metrilyx/rest/apiviews.py
@@ -25,159 +25,159 @@ from metrilyx import metrilyxconfig
 from pprint import pprint
 
 class UserViewSet(viewsets.ModelViewSet):
-	permission_classes = (permissions.IsAuthenticated,)
-	queryset = User.objects.all()
-	serializer_class = UserSerializer
+    permission_classes = (permissions.IsAuthenticated,)
+    queryset = User.objects.all()
+    serializer_class = UserSerializer
 
 
 class GroupViewSet(viewsets.ModelViewSet):
-	permission_classes = (permissions.IsAuthenticated,)
-	queryset = Group.objects.all()
-	serializer_class = GroupSerializer
+    permission_classes = (permissions.IsAuthenticated,)
+    queryset = Group.objects.all()
+    serializer_class = GroupSerializer
 
 
 class MapViewSet(viewsets.ModelViewSet):
-	"""
-	This class is not directly used.  It is subclassed by heatmaps and graphmaps.
-	"""
-	serializer_class = MapModelSerializer
-	permission_classes = (permissions.IsAuthenticatedOrReadOnly,
-			IsGroupOrReadOnly, IsCreatorOrReadOnly)
+    """
+    This class is not directly used.  It is subclassed by heatmaps and graphmaps.
+    """
+    serializer_class = MapModelSerializer
+    permission_classes = (permissions.IsAuthenticatedOrReadOnly,
+            IsGroupOrReadOnly, IsCreatorOrReadOnly)
 
-	filter_backends = (filters.SearchFilter,)
-	search_fields = ('name', '_id', 'tags',)
+    filter_backends = (filters.SearchFilter,)
+    search_fields = ('name', '_id', 'tags',)
 
-	def pre_save(self, obj):
-		obj.user = self.request.user
+    def pre_save(self, obj):
+        obj.user = self.request.user
 
 class GraphMapViewSet(MapViewSet):
 
-	queryset = MapModel.objects.filter(model_type="graph")
+    queryset = MapModel.objects.filter(model_type="graph")
 
-	def pre_save(self, obj):
-		super(GraphMapViewSet,self).pre_save(obj)
-		obj.model_type = "graph"
+    def pre_save(self, obj):
+        super(GraphMapViewSet,self).pre_save(obj)
+        obj.model_type = "graph"
 
 
-	def list(self, request, pk=None):
-		# w/out this not all models show up in the listing.
-		queryset = MapModel.objects.filter(model_type="graph")
-		serializer = MapModelListSerializer(queryset, many=True)
-		return Response(serializer.data)
+    def list(self, request, *args, **kwargs):
+        # w/out this not all models show up in the listing.
+        queryset = MapModel.objects.filter(model_type="graph")
+        serializer = MapModelListSerializer(queryset, many=True)
+        return Response(serializer.data)
 
-	def retrieve(self, request, pk=None):
-		export_model = request.GET.get('export', None)
-		if export_model == None:
-			return super(GraphMapViewSet, self).retrieve(request,pk)
-		else:
-			graphmap = get_object_or_404(MapModel, model_type='graph', _id=pk)
-			serializer = MapModelSerializer(graphmap)
-			request.accepted_media_type = "application/json; indent=4"
-			return Response(serializer.data, headers={
-				'Content-Disposition': 'attachment; filename: %s.json' %(pk),
-				'Content-Type': 'application/json'
-				})
+    def retrieve(self, request, *args, **kwargs):
+        export_model = request.GET.get('export', None)
+        if export_model == None:
+            return super(GraphMapViewSet, self).retrieve(request,kwargs['pk'])
+        else:
+            graphmap = get_object_or_404(MapModel, model_type='graph', _id=kwargs['pk'])
+            serializer = MapModelSerializer(graphmap)
+            request.accepted_media_type = "application/json; indent=4"
+            return Response(serializer.data, headers={
+                'Content-Disposition': 'attachment; filename: %s.json' %(kwargs['pk']),
+                'Content-Type': 'application/json'
+                })
 
 
 class SchemaViewSet(viewsets.ViewSet):
 
-	def list(self, request):
-		schemas = [ os.path.splitext(x)[0] for x in os.listdir(config['schema_path']) ]
-		return Response(schemas)
+    def list(self, request):
+        schemas = [ os.path.splitext(x)[0] for x in os.listdir(config['schema_path']) ]
+        return Response(schemas)
 
-	def retrieve(self, request, pk=None):
-		try:
-			schema = json.load(open(os.path.join(config['schema_path'], pk+".json" )))
-			if pk == 'graph':
-				schema['_id'] = metrilyx.new_uuid()
-			return Response(schema)
-		except Exception,e:
-			return Response({"error": str(e)})
+    def retrieve(self, request, pk=None):
+        try:
+            schema = json.load(open(os.path.join(config['schema_path'], pk+".json" )))
+            if pk == 'graph':
+                schema['_id'] = metrilyx.new_uuid()
+            return Response(schema)
+        except Exception,e:
+            return Response({"error": str(e)})
 
 
 class ConfigurationView(APIView):
 
-	def __annotationsConfig(self):
-		if config["annotations"]:
-			return config["annotations"]
-		return {}
+    def __annotationsConfig(self):
+        if config["annotations"]:
+            return config["annotations"]
+        return {}
 
-	def __metricSearchConfig(self):
-		if config['cache']['enabled']:
-			return { 'uri': config['cache']['datasource']['url'] }
-		else:
-			return {'uri': '/api/search'}
+    def __metricSearchConfig(self):
+        if config['cache']['enabled']:
+            return { 'uri': config['cache']['datasource']['url'] }
+        else:
+            return {'uri': '/api/search'}
 
-	def __websocketConfig(self):
-		hostname = socket.gethostname()
-		resp = {
-			'hostname': hostname,
-			'extensions': ['compressed=true']
-			}
+    def __websocketConfig(self):
+        hostname = socket.gethostname()
+        resp = {
+            'hostname': hostname,
+            'extensions': ['compressed=true']
+            }
 
-		if config['websocket'].has_key('hostname'):
-			resp['hostname'] = config['websocket']['hostname']
+        if config['websocket'].has_key('hostname'):
+            resp['hostname'] = config['websocket']['hostname']
 
-		if config['websocket'].has_key('ssl') and config['websocket']['ssl']:
-			resp['uri'] = 'wss://%s' % (resp['hostname'])
-		else:
-			resp['uri'] = 'ws://%s' % (resp['hostname'])
+        if config['websocket'].has_key('ssl') and config['websocket']['ssl']:
+            resp['uri'] = 'wss://%s' % (resp['hostname'])
+        else:
+            resp['uri'] = 'ws://%s' % (resp['hostname'])
 
-		if config['websocket'].has_key('port'):
-			resp['port'] = config['websocket']['port']
-			resp['uri'] = "%s:%d" %(resp['uri'], resp['port'])
+        if config['websocket'].has_key('port'):
+            resp['port'] = config['websocket']['port']
+            resp['uri'] = "%s:%d" %(resp['uri'], resp['port'])
 
-		if config['websocket'].has_key('endpoint'):
-			resp['endpoint'] = config['websocket']['endpoint']
-			resp['uri'] = "%s%s" %(resp['uri'], resp['endpoint'])
+        if config['websocket'].has_key('endpoint'):
+            resp['endpoint'] = config['websocket']['endpoint']
+            resp['uri'] = "%s%s" %(resp['uri'], resp['endpoint'])
 
-		resp['uri'] = "%s?%s" %(resp['uri'], "&".join(resp['extensions']))
+        resp['uri'] = "%s?%s" %(resp['uri'], "&".join(resp['extensions']))
 
-		return resp
+        return resp
 
-	def get(self, request, pk=None):
-		'''
-			Websocket connection information for client requests.
-		'''
-		response = {
-			'annotations': self.__annotationsConfig(),
-			'websocket': self.__websocketConfig(),
-			'metric_search': self.__metricSearchConfig()
-			}
+    def get(self, request, pk=None):
+        '''
+            Websocket connection information for client requests.
+        '''
+        response = {
+            'annotations': self.__annotationsConfig(),
+            'websocket': self.__websocketConfig(),
+            'metric_search': self.__metricSearchConfig()
+            }
 
-		return Response(response)
+        return Response(response)
 
 class TagViewSet(viewsets.ViewSet):
 
-	def __get_unique_tags(self, model_type=''):
-		## distinct() is not handled properly when using json in postgres
-		if model_type != '':
-			objs = MapModel.objects.filter(model_type=model_type).values_list('tags',flat=True)
-		else:
-			objs = MapModel.objects.values_list('tags',flat=True)
-		## this is to handle db's that dont' support json types
-		if len(objs) < 1:
-			return []
-		if type(objs[0]) in (str,unicode): objs = [ json.loads(o) for o in objs ]
-		objs = [ o for o in objs if len(o) > 0 ]
-		out = []
-		for o in objs:
-			out += [ t for t in o if t not in out ]
-		return sorted(out)
+    def __get_unique_tags(self, model_type=''):
+        ## distinct() is not handled properly when using json in postgres
+        if model_type != '':
+            objs = MapModel.objects.filter(model_type=model_type).values_list('tags',flat=True)
+        else:
+            objs = MapModel.objects.values_list('tags',flat=True)
+        ## this is to handle db's that dont' support json types
+        if len(objs) < 1:
+            return []
+        if type(objs[0]) in (str,unicode): objs = [ json.loads(o) for o in objs ]
+        objs = [ o for o in objs if len(o) > 0 ]
+        out = []
+        for o in objs:
+            out += [ t for t in o if t not in out ]
+        return sorted(out)
 
-	def list(self, request, pk=None):
-		model_type = request.GET.get('model_type', '')
-		tags = self.__get_unique_tags(model_type)
-		return Response([ {'name': t } for t in tags ])
+    def list(self, request, pk=None):
+        model_type = request.GET.get('model_type', '')
+        tags = self.__get_unique_tags(model_type)
+        return Response([ {'name': t } for t in tags ])
 
-	def retrieve(self, request, pk=None):
-		model_type = request.GET.get('model_type', '')
-		if model_type == '':
-			objs = MapModel.objects.filter(tags__contains=pk)
-		else:
-			objs = MapModel.objects.filter(tags__contains=pk, model_type=model_type)
-		serializer = MapModelSerializer(objs, many=True)
-		return Response(serializer.data)
+    def retrieve(self, request, pk=None):
+        model_type = request.GET.get('model_type', '')
+        if model_type == '':
+            objs = MapModel.objects.filter(tags__contains=pk)
+        else:
+            objs = MapModel.objects.filter(tags__contains=pk, model_type=model_type)
+        serializer = MapModelSerializer(objs, many=True)
+        return Response(serializer.data)
 
 class OpenTSDBMetaSearch(object):
     """
@@ -185,46 +185,46 @@ class OpenTSDBMetaSearch(object):
     metric metadata caching is disabled.
     """
     def __init__(self, config):
-    	self.suggest_limit = config["suggest_limit"]
+        self.suggest_limit = config["suggest_limit"]
         self.tsdb_suggest_url = "%(uri)s:%(port)d%(search_endpoint)s" %(config)
 
     def search(self, obj, limit=None):
         if obj["type"] == "metric":
             obj["type"] = "metrics"
         if limit != None:
-        	resp = requests.get("%s?max=%d&type=%s&q=%s" %(self.tsdb_suggest_url,
-        										limit, obj['type'], obj['query']))
+            resp = requests.get("%s?max=%d&type=%s&q=%s" %(self.tsdb_suggest_url,
+                                                limit, obj['type'], obj['query']))
         else:
-        	resp = requests.get("%s?max=%d&type=%s&q=%s" %(self.tsdb_suggest_url,
-        							self.suggest_limit, obj['type'], obj['query']))
+            resp = requests.get("%s?max=%d&type=%s&q=%s" %(self.tsdb_suggest_url,
+                                    self.suggest_limit, obj['type'], obj['query']))
         return resp.json()
 
 class SearchViewSet(viewsets.ViewSet):
 
-	def __init__(self, *args, **kwargs):
-		super(SearchViewSet, self).__init__(*args, **kwargs)
-		# Only used if cache is disabled
-		self.metricMetaSearch = OpenTSDBMetaSearch(config["dataprovider"])
+    def __init__(self, *args, **kwargs):
+        super(SearchViewSet, self).__init__(**kwargs)
+        # Only used if cache is disabled
+        self.metricMetaSearch = OpenTSDBMetaSearch(config["dataprovider"])
 
-	def list(self, request, pk=None):
-		return Response(['graphmaps', 'heatmaps', 'metrics', 'tagk', 'tagv', 'event_types'])
+    def list(self, request, pk=None):
+        return Response(['graphmaps', 'heatmaps', 'metrics', 'tagk', 'tagv', 'event_types'])
 
-	def retrieve(self, request, pk=None):
-		query = request.GET.get('q', '')
-		limit = request.GET.get('limit', config['dataprovider']['suggest_limit'])
+    def retrieve(self, request, pk=None):
+        query = request.GET.get('q', '')
+        limit = request.GET.get('limit', config['dataprovider']['suggest_limit'])
 
-		if query == '':
-			response = []
-		elif pk == 'graphmaps':
-			models_obj = MapModel.objects.filter(name__contains=query, model_type='graph')
-			serializer_obj = MapModelSerializer(models_obj, many=True)
-			response = serializer_obj.data
-		elif pk == 'event_types':
-			models_obj = EventType.objects.filter(name__contains=query)
-			serializer_obj = EventTypeSerializer(models_obj,many=True)
-			response = serializer_obj.data
-		elif pk in ('tagk','tagv', 'metrics'):
-			response = self.metricMetaSearch.search({'type':pk,'query':query},limit=limit)
-		else:
-			response = {"error": "Invalid search: %s" %(pk)}
-		return Response(response)
+        if query == '':
+            response = []
+        elif pk == 'graphmaps':
+            models_obj = MapModel.objects.filter(name__contains=query, model_type='graph')
+            serializer_obj = MapModelSerializer(models_obj, many=True)
+            response = serializer_obj.data
+        elif pk == 'event_types':
+            models_obj = EventType.objects.filter(name__contains=query)
+            serializer_obj = EventTypeSerializer(models_obj,many=True)
+            response = serializer_obj.data
+        elif pk in ('tagk','tagv', 'metrics'):
+            response = self.metricMetaSearch.search({'type':pk,'query':query},limit=limit)
+        else:
+            response = {"error": "Invalid search: %s" %(pk)}
+        return Response(response)

--- a/metrilyx/rest/apiviews.py
+++ b/metrilyx/rest/apiviews.py
@@ -25,13 +25,13 @@ from metrilyx import metrilyxconfig
 from pprint import pprint
 
 class UserViewSet(viewsets.ModelViewSet):
-    permission_classes = (permissions.IsAuthenticated,)
+    #permission_classes = (permissions.IsAuthenticated,)
     queryset = User.objects.all()
     serializer_class = UserSerializer
 
 
 class GroupViewSet(viewsets.ModelViewSet):
-    permission_classes = (permissions.IsAuthenticated,)
+    #permission_classes = (permissions.IsAuthenticated,)
     queryset = Group.objects.all()
     serializer_class = GroupSerializer
 
@@ -41,8 +41,8 @@ class MapViewSet(viewsets.ModelViewSet):
     This class is not directly used.  It is subclassed by heatmaps and graphmaps.
     """
     serializer_class = MapModelSerializer
-    permission_classes = (permissions.IsAuthenticatedOrReadOnly,
-            IsGroupOrReadOnly, IsCreatorOrReadOnly)
+    #permission_classes = (permissions.IsAuthenticatedOrReadOnly,
+    #        IsGroupOrReadOnly, IsCreatorOrReadOnly)
 
     filter_backends = (filters.SearchFilter,)
     search_fields = ('name', '_id', 'tags',)

--- a/metrilyx/rest/customfields.py
+++ b/metrilyx/rest/customfields.py
@@ -5,13 +5,13 @@ from rest_framework import serializers
 class JSONField(serializers.WritableField):
 
     def to_native(self, obj):
-    	#print "to_native"
-    	if type(obj) is str:
-    		return json.loads(obj)
-    	return obj
+        #print "to_native"
+        if type(obj) is str:
+            return json.loads(obj)
+        return obj
 
     def from_native(self, value):
-    	#print "from_native"
-    	if type(value) is str:
-    		return json.loads(value)
-    	return value
+        #print "from_native"
+        if type(value) is str:
+            return json.loads(value)
+        return value

--- a/www/app/config.js
+++ b/www/app/config.js
@@ -19,12 +19,12 @@ var CONN_POOL_CFG = {
 	urls: []
 };
 /* Auth config until auth is enabled. This is just a future placeholder. */
-var AUTHCONFIG = {
-	modelstore: {
-		username: 'admin',
-		password: 'metrilyx'
-	}
-};
+//var AUTHCONFIG = {
+//	modelstore: {
+//		username: 'admin',
+//		password: 'metrilyx'
+//	}
+//};
 /* WebSocket URI */
 //var WS_URI = "ws://"+SERVER_NAME+"/api/data?compressed=true";
 

--- a/www/app/services.js
+++ b/www/app/services.js
@@ -41,7 +41,7 @@ angular.module('metrilyxServices', ['ngResource'])
 			if (query == "") {
 			    dfd.resolve([]);
 			} else if(cache[query] === undefined){
-			    Auth.clearCredentials();
+//			    Auth.clearCredentials();
 			    // TODO: check query url
 			    //$http.get(queryURL+query)
 			    $http.get(Configuration.metric_search.uri + "/metrics?q=" + query)
@@ -71,28 +71,28 @@ angular.module('metrilyxServices', ['ngResource'])
 			saveModel: {
 				method:'POST',
 				isArray:false,
-				headers: Auth.authHeaders(AUTHCONFIG.modelstore.username,
-											AUTHCONFIG.modelstore.password)
+//				headers: Auth.authHeaders(AUTHCONFIG.modelstore.username,
+//											AUTHCONFIG.modelstore.password)
 			},
 			editModel: {
 				method:'PUT',
 				params:{pageId:'@pageId'},
 				isArray:false,
-				headers: Auth.authHeaders(AUTHCONFIG.modelstore.username,
-											AUTHCONFIG.modelstore.password)
+//				headers: Auth.authHeaders(AUTHCONFIG.modelstore.username,
+//											AUTHCONFIG.modelstore.password)
 			},
 			removeModel:{
 				method:'DELETE',
 				params:{pageId:'@pageId'},
-				headers: Auth.authHeaders(AUTHCONFIG.modelstore.username,
-											AUTHCONFIG.modelstore.password)
+//				headers: Auth.authHeaders(AUTHCONFIG.modelstore.username,
+//											AUTHCONFIG.modelstore.password)
 			}
 		});
 	}
 ])
 .factory('Tags', ['$resource', 'Auth',
 	function($resource, Auth) {
-		Auth.clearCredentials();
+//		Auth.clearCredentials();
 		return $resource(connectionPool.nextConnection()+'/api/tags/:tagname', {}, {
 			listTags: {
 				method:'GET',
@@ -114,7 +114,7 @@ angular.module('metrilyxServices', ['ngResource'])
 			get : function(params, cb){
 				var dfd = $.Deferred();
 				if (params.modelType === 'graph' || cache[params.modelType] === undefined){
-					Auth.clearCredentials();
+//					Auth.clearCredentials();
 					$http.get(connectionPool.nextConnection()+'/api/schemas/' + params.modelType).success(function(res){
 						if(params.modelType !== 'graph') {
 							dfd.resolve(res)


### PR DESCRIPTION
**`a7efaf8`: Ignore Virtualenv directory and PyCharm project directory**

Modifies .gitignore to support the Virtualenv `env` directory and the IntelliJ IDE `.idea` project directory.

**`a7c8a66`: Fix some low hanging fruit from static analysis**

Fixes several issues found during static analysis, including lots of inconsistent indentation, a few inconsistent arguments lists in overridden methods, some uninitialized locals, and a few potential bugs (`import time` and `tsval`).

Some more potential bugs may exist, but I don't understand the dependency graph enough to safely address them.

**`010ea6f`: Remove 401 Auth requirement**

Comment out parts of code that implement 401 Authorization. Previously this was addressed by forcing a hardcoded "admin/metrilyx" user. This is an issue in my use-case since we are addressing Metrilyx's lack of AAA by placing it behind our own 401 Authentication handled by Nginx.