### PR TITLE
Un-hardcode Metrilyx configuration directory

### DIFF
--- a/metrilyx/metrilyxconfig.py
+++ b/metrilyx/metrilyxconfig.py
@@ -14,10 +14,13 @@ _apphome = os.environ.get('METRILYX_HOME')
 if _apphome == None:
     print " * Warning: METRILYX_HOME environment variable not set!"
     _apphome = os.path.dirname(os.path.dirname(_abspath))
+_appconf = os.environ.get('METRILYX_CONF')
+if _appconf == None:
+    _appconf = os.path.join(_apphome, "etc/metrilyx")
 
 _appversion = open(os.path.join(_apphome, "VERSION")).read()
 
-CONFIG_FILE = os.path.join(_apphome, "etc/metrilyx/metrilyx.conf")
+CONFIG_FILE = os.path.join(os.path.join(_apphome, _appconf), "metrilyx.conf")
 if not os.path.exists(CONFIG_FILE):
     raise RuntimeError("Configuration file not found: %s!" % (CONFIG_FILE))
 
@@ -43,12 +46,12 @@ if not config.has_key("static_path"):
     config["static_path"] = os.path.join(os.path.dirname(_apphome), "www")
 
 if not config.has_key("schema_path"):
-    config["schema_path"] = os.path.join(_apphome, "etc/metrilyx/schemas")
+    config["schema_path"] = os.path.join(os.path.join(_apphome, _appconf), "schemas")
 
 if config["version"].startswith("2.4"):
     adp = config['annotations']['dataprovider']
     if not adp.has_key('default_mapping'):
-        adp['default_mapping'] = os.path.join(_apphome, "etc/metrilyx/ess-default-mappings.json")
+        adp['default_mapping'] = os.path.join(os.path.join(_apphome, _appconf), "ess-default-mappings.json")
 
     default_mapping = jsonFromFile(adp['default_mapping'])
     if default_mapping.has_key('error'):


### PR DESCRIPTION
I'm breaking /opt/metrilyx/* out into /etc/metrilyx, /var/log/metrilyx, /usr/bin/metrilyx, etc, and this is the only place where an instance of hardcoding is hampering me.